### PR TITLE
Avoid error in GADM is offline

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -99,6 +99,7 @@ Suggests:
     rmarkdown,
     ISOcodes,
     testthat (>= 3.0.0),
+    rnaturalearthdata,
     covr
 VignetteBuilder: knitr
 URL: https://github.com/oggioniale/ReLTER

--- a/R/produce_network_points_map.R
+++ b/R/produce_network_points_map.R
@@ -81,14 +81,18 @@ produce_network_points_map <- function(networkDEIMSID, countryCode) {
       )
       if (any(networkSitesGeo_valid)) {
         if (countryCode %in% isoCodes$Alpha_3 == TRUE) {
-          country <- raster::getData(country = countryCode, level = 0)
-          country <- rgeos::gSimplify(
-            country,
-            tol = 0.01,
-            topologyPreserve = TRUE
-          )
-          mapOfSites <- tmap::tm_shape(country) +
-            tmap::tm_borders("grey75", lwd = 1) +
+          try({
+            country <- raster::getData(country = countryCode, level = 0) %>%
+              rgeos::gSimplify(
+                tol = 0.01,
+                topologyPreserve = TRUE
+              )
+          })
+          mapOfSites <- if (exists("country")) {
+            tmap::tm_shape(country) +
+              tmap::tm_borders("grey75", lwd = 1)
+          } else {NULL}
+          mapOfSites <- mapOfSites +
             tmap::tm_shape(networkSitesGeo) +
             tmap::tm_dots(
               col = NA,

--- a/R/produce_site_map.R
+++ b/R/produce_site_map.R
@@ -174,12 +174,13 @@ produce_site_map <-
              deimsidExa)
       )$attributes$geographic$boundaries
     if (countryCode %in% isoCodes$Alpha_3 == TRUE) {
-      country <- raster::getData(
-        country = countryCode,
-        level = 0
-      )
-      country <-
-        rgeos::gSimplify(country, tol = 0.01, topologyPreserve = TRUE)
+      try({
+        country <- raster::getData(
+          country = countryCode,
+          level = 0
+        ) %>%
+          rgeos::gSimplify(tol = 0.01, topologyPreserve = TRUE)
+      }, silent = TRUE)
       if (is.null(geoBoundaries)) {
         lterCoords <- siteSelected
         lterSitesFeaturePointDEIMS <-
@@ -233,7 +234,8 @@ produce_site_map <-
             position = c("left", "bottom")
           ) +
           tmap::tm_basemap(leaflet::providers$Stamen.Watercolor)
-        mapOfCentroids <- tmap::tm_shape(country) +
+        if (exists("country")) {
+          mapOfCentroids <- tmap::tm_shape(country) +
           tmap::tm_borders("grey75", lwd = 1) +
           tmap::tm_shape(listOfSites) +
           tmap::tm_dots(
@@ -251,14 +253,19 @@ produce_site_map <-
             title = NA,
             legend.show = FALSE
           )
+        }
         # based on the value of show_map param
         if (show_map == TRUE) {
-          print(mapOfSite)
-          print(mapOfCentroids,
-                vp = grid::viewport(gridNx,
-                                    gridNy,
-                                    width = width,
-                                    height = height))
+          if (exists("mapOfCentroids")) {
+            print(mapOfSite)
+            print(mapOfCentroids,
+                  vp = grid::viewport(gridNx,
+                                      gridNy,
+                                      width = width,
+                                      height = height))
+          } else {
+            print(mapOfSite)
+          }
         } else {
           return(mapOfSite)
           return(mapOfCentroids,
@@ -327,6 +334,7 @@ produce_site_map <-
             position = c("left", "bottom")
           ) +
           tmap::tm_basemap(leaflet::providers$Stamen.Watercolor)
+        if (exists("country")) {
           mapOfCentroids <- tmap::tm_shape(country) +
             tmap::tm_borders("grey75", lwd = 1) +
             tmap::tm_shape(listOfSites) +
@@ -345,16 +353,21 @@ produce_site_map <-
               title = NA,
               legend.show = FALSE
             )
+        }
         if (show_map == TRUE) {
-          print(mapOfSite)
-          print(mapOfCentroids,
-                vp = grid::viewport(
-                  gridNx,
-                  gridNy,
-                  width = width,
-                  height = height
-                )
-          )
+          if (exists("mapOfCentroids")) {
+            print(mapOfSite)
+            print(mapOfCentroids,
+                  vp = grid::viewport(
+                    gridNx,
+                    gridNy,
+                    width = width,
+                    height = height
+                  )
+            )
+          } else {
+            print(mapOfSite)
+          }
         } else {
           return(mapOfSite)
           return(mapOfCentroids,


### PR DESCRIPTION
`raster::getData()` can fail if the remoteserver from which it tries to download boundaries is offline. This PR skip printing boundaries if that occurs.